### PR TITLE
fix(blog): incorrect toc location from mdsvex upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-svelte": "^2.36.0",
 				"globals": "^15.0.0",
-				"mdsvex": "^0.12.5",
+				"mdsvex": "^0.12.3",
 				"prettier": "^3.3.2",
 				"prettier-plugin-svelte": "^3.1.2",
 				"prettier-plugin-tailwindcss": "^0.6.11",
@@ -4671,63 +4671,19 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdsvex": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/mdsvex/-/mdsvex-0.12.5.tgz",
-			"integrity": "sha512-JQy8CBbGF1IvpxZTmGJigRiD1s2BKfLKS9xCLPKngjHToY8WMYLZ8WFGRpuR6x4C4bxipSuLm2LctwL2fVXaEQ==",
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/mdsvex/-/mdsvex-0.12.3.tgz",
+			"integrity": "sha512-C/uIJamjNo5PHHnR3JHqsBPoLcfUBpzRmAEB6FLMXI/s7XHOceswjDMKqSPEW2WHmYpKm0taZ3U20GSyhMridA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/mdast": "^4.0.4",
 				"@types/unist": "^2.0.3",
 				"prism-svelte": "^0.4.7",
 				"prismjs": "^1.17.1",
-				"unist-util-visit": "^2.0.1",
 				"vfile-message": "^2.0.4"
 			},
 			"peerDependencies": {
 				"svelte": "^3.56.0 || ^4.0.0 || ^5.0.0-next.120"
-			}
-		},
-		"node_modules/mdsvex/node_modules/unist-util-is": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-			"integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdsvex/node_modules/unist-util-visit": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-			"integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdsvex/node_modules/unist-util-visit-parents": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-			"integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"format:main": "cd apps/main && prettier --write .",
 		"format:resume": "cd apps/resume && prettier --write ."
 	},
+	"//": "Note that mdsvex is locked to 0.12.3. Any higher than that breaks where rehype-toc places the `<nav />`",
 	"devDependencies": {
 		"@sveltejs/adapter-vercel": "^5.7.0",
 		"@sveltejs/kit": "^2.20.7",
@@ -51,7 +52,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.36.0",
 		"globals": "^15.0.0",
-		"mdsvex": "^0.12.5",
+		"mdsvex": "0.12.3",
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.1.2",
 		"prettier-plugin-tailwindcss": "^0.6.11",


### PR DESCRIPTION
## Description

Somehow, upgrading mdsvex from 0.11.2 to 0.12.5 in

- https://github.com/camball/camball.io/pull/89

broke the placement of my table of contents `<nav>...</nav>`.

Before, it was placed as:

```html
<main>...</main>
<nav>...</nav>
```

, but after upgrading the library, it was transformed to

```html
<main>
  <article>
    <nav>...</nav>
    <slot />
  </article>
</main>
```

all for the same rehypeToc config of `{ position: 'beforeend' }`.

Not sure how or why, but the latest version of mdsvex that doesn't break this functionality is 0.12.3, so I locked the version to that in this PR. As soon as I upgrade to 0.12.4, the build breaks, and with 0.12.5, the build succeeds, but current functionality breaks, so pinning to 0.12.3 for now.