### PR TITLE
fix(blog): jumpy scroll area from dynamic viewport

### DIFF
--- a/apps/blog/src/routes/+page.svelte
+++ b/apps/blog/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Header />
-<div class="flex h-screen bg-neutral-50 dark:bg-neutral-900">
+<div class="flex h-[100svh] bg-neutral-50 sm:h-screen dark:bg-neutral-900">
     <div class="absolute sm:mt-20 sm:ml-20">
         <BinaryTextOverlay text={"discipline"} />
     </div>


### PR DESCRIPTION
closes #97

## Description

No longer does the page scroll when you try to scroll the scroll area for navigating the list of blog articles. This led to annoying behaviour especially when the page first loads.