### PR TITLE
ci(build): pin node version to major

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": ">=22"
+    "node": "^22"
   },
   "//": "Note that mdsvex is locked to 0.12.3. Any higher than that breaks where rehype-toc places the `<nav />`",
   "devDependencies": {


### PR DESCRIPTION
## Description

Fix Vercel build failing due to:

```text
Warning: Due to "engines": { "node": ">=22" } in your `package.json` file, the Node.js Version defined in your Project Settings ("22.x") will not apply, Node.js Version "24.x" will be used instead. Learn More: https://vercel.link/node-version
Warning: Detected "engines": { "node": ">=22" } in your `package.json` that will automatically upgrade when a new major Node.js Version is released. Learn More: https://vercel.link/node-version
...
error during build:
Error: Unsupported Node.js version: v24.13.0. Please use Node 20 or 22 to build your project, or explicitly specify a runtime in your adapter configuration.
    at get_default_runtime (file:///vercel/path0/node_modules/.pnpm/@sveltejs+adapter-vercel@6.1.1_@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte_hgaoc2eae7v3o4ojocmskfsqsm/node_modules/@sveltejs/adapter-vercel/utils.js:131:9)
    at resolve_runtime (file:///vercel/path0/node_modules/.pnpm/@sveltejs+adapter-vercel@6.1.1_@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte_hgaoc2eae7v3o4ojocmskfsqsm/node_modules/@sveltejs/adapter-vercel/utils.js:118:46)
    at adapt (file:///vercel/path0/node_modules/.pnpm/@sveltejs+adapter-vercel@6.1.1_@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte_hgaoc2eae7v3o4ojocmskfsqsm/node_modules/@sveltejs/adapter-vercel/index.js:273:21)
    at adapt (file:///vercel/path0/node_modules/.pnpm/@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte@5.43.5_vite@7.2.2_jiti@2.4.2_l_fs4zgycatwty7sxfj3oob56sdq/node_modules/@sveltejs/kit/src/core/adapt/index.js:41:8)
    at finalise (file:///vercel/path0/node_modules/.pnpm/@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte@5.43.5_vite@7.2.2_jiti@2.4.2_l_fs4zgycatwty7sxfj3oob56sdq/node_modules/@sveltejs/kit/src/exports/vite/index.js:1315:13)
    at async Object.handler (file:///vercel/path0/node_modules/.pnpm/@sveltejs+kit@2.48.4_@sveltejs+vite-plugin-svelte@6.2.1_svelte@5.43.5_vite@7.2.2_jiti@2.4.2_l_fs4zgycatwty7sxfj3oob56sdq/node_modules/@sveltejs/kit/src/exports/vite/index.js:1346:5)
    at async PluginDriver.hookParallel (file:///vercel/path0/node_modules/.pnpm/rollup@4.53.1/node_modules/rollup/dist/es/shared/node-entry.js:22341:17)
    at async Object.close (file:///vercel/path0/node_modules/.pnpm/rollup@4.53.1/node_modules/rollup/dist/es/shared/node-entry.js:23360:13)
    at async buildEnvironment (file:///vercel/path0/node_modules/.pnpm/vite@7.2.2_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/dist/node/chunks/config.js:34174:15)
    at async Object.build (file:///vercel/path0/node_modules/.pnpm/vite@7.2.2_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/dist/node/chunks/config.js:34519:19)
Error: Command "vite build" exited with 1
```