### PR TITLE
feat(blog): add callout styling/support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supports...
   - [Tailwind Typography](https://github.com/tailwindlabs/tailwindcss-typography) for content styling
   - [prism-themes](https://github.com/prismjs/prism-themes) for syntax highlighting
   - [remark-gfm](https://github.com/remarkjs/remark-gfm) for GFM (GitHub Flavored Markdown) support
+  - [remark-callout](https://github.com/r4ai/remark-callout) for markdown callout support
   - [rehype-slug](https://github.com/rehypejs/rehype-slug) for auto-adding `id`s to headings
   - [rehype-autolink-headings](https://github.com/rehypejs/rehype-autolink-headings) for auto-adding anchor tags to headings
   - [rehype-toc](https://github.com/JS-DevTools/rehype-toc) for auto-generating a table of contents

--- a/apps/blog/remark-callout-fix.js
+++ b/apps/blog/remark-callout-fix.js
@@ -1,0 +1,27 @@
+/**
+ * This plugin is a hacky patch for undesired behaviour in MDsveX.
+ *
+ * MDsveX parses `[!note]` as a link reference. We fix this by converting the
+ * callout opening node back to plain text so it doesn't get transformed before
+ * remark-callout can process it.
+ *
+ * See https://github.com/pngwn/MDsveX/issues/737
+ */
+export default function remarkCalloutFix() {
+    return (tree) => {
+        const walk = (node, parent, index) => {
+            if (node.type === "linkReference" && node.label?.startsWith("!")) {
+                if (parent && typeof index === "number") {
+                    parent.children[index] = {
+                        type: "text",
+                        value: `[${node.label}]`,
+                    };
+                }
+            }
+            if (node.children) {
+                node.children.forEach((child, i) => walk(child, node, i));
+            }
+        };
+        walk(tree);
+    };
+}

--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -2,6 +2,7 @@
 /* from other monorepo subprojects. `lib/` imported in the root `app.css`. */
 @import "tailwindcss" source("../src");
 @import "../../lib/app.css";
+@import "./callouts.css";
 
 @plugin "@tailwindcss/typography";
 

--- a/apps/blog/src/callouts.css
+++ b/apps/blog/src/callouts.css
@@ -1,0 +1,312 @@
+/* remark-callout styles */
+/* Sourced from https://r4ai.github.io/remark-callout/playground/ */
+[data-callout] {
+    & {
+        @apply my-6 rounded-lg border border-blue-600/20 bg-blue-400/20 p-4 pb-5 dark:border-blue-800/20 dark:bg-blue-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply flex flex-row items-start gap-2 p-0 font-bold text-blue-500;
+        }
+        &:not:only-child {
+            @apply mb-2;
+        }
+        &:empty::after {
+            content: "Note";
+        }
+        &::before {
+            @apply mt-1 block h-5 w-5 bg-current content-[""];
+            mask-repeat: no-repeat;
+            mask-size: cover;
+            /* lucide-pencil */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTE3IDNhMi44NSAyLjgzIDAgMSAxIDQgNEw3LjUgMjAuNUwyIDIybDEuNS01LjVabS0yIDJsNCA0Ii8+PC9zdmc+");
+        }
+    }
+    & > [data-callout-body] {
+        & {
+            @apply mt-2 space-y-2;
+        }
+        & > * {
+            @apply m-0;
+        }
+    }
+}
+details[data-callout] > summary[data-callout-title] {
+    & {
+        @apply cursor-pointer;
+    }
+    &::after {
+        @apply w-full bg-right bg-no-repeat;
+        content: "";
+        /* lucide:chevron-right */
+        background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzg4ODg4OCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiIGQ9Im05IDE4bDYtNmwtNi02Ii8+PC9zdmc+");
+        background-size: 1.5rem;
+    }
+    &:not(:empty)::after {
+        @apply my-auto ml-auto h-6 w-6;
+    }
+}
+details[data-callout][open] > summary[data-callout-title]::after {
+    /* lucide:chevron-down */
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzg4ODg4OCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiIGQ9Im02IDlsNiA2bDYtNiIvPjwvc3ZnPg==");
+}
+[data-callout][data-callout-type="info"] {
+    & {
+        @apply border-blue-600/20 bg-blue-400/20 dark:border-blue-800/20 dark:bg-blue-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-blue-500;
+        }
+        &:empty::after {
+            content: "Info";
+        }
+        &::before {
+            /* lucide:info */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzg4ODg4OCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEwIi8+PHBhdGggZD0iTTEyIDE2di00bTAtNGguMDEiLz48L2c+PC9zdmc+");
+        }
+    }
+}
+[data-callout][data-callout-type="todo"] {
+    & {
+        @apply border-blue-600/20 bg-blue-400/20 dark:border-blue-800/20 dark:bg-blue-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-blue-500;
+        }
+        &:empty::after {
+            content: "ToDo";
+        }
+        &::before {
+            /* lucide:circle-check-big */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzg4ODg4OCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiPjxwYXRoIGQ9Ik0yMiAxMS4wOFYxMmExMCAxMCAwIDEgMS01LjkzLTkuMTQiLz48cGF0aCBkPSJtOSAxMWwzIDNMMjIgNCIvPjwvZz48L3N2Zz4=");
+        }
+    }
+}
+[data-callout][data-callout-type="abstract"],
+[data-callout][data-callout-type="summary"],
+[data-callout][data-callout-type="tldr"] {
+    & {
+        @apply border-cyan-600/20 bg-cyan-400/20 dark:border-cyan-800/20 dark:bg-cyan-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-cyan-500;
+        }
+        &::before {
+            /* lucide:clipboard-list */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiI+PHJlY3Qgd2lkdGg9IjgiIGhlaWdodD0iNCIgeD0iOCIgeT0iMiIgcng9IjEiIHJ5PSIxIi8+PHBhdGggZD0iTTE2IDRoMmEyIDIgMCAwIDEgMiAydjE0YTIgMiAwIDAgMS0yIDJINmEyIDIgMCAwIDEtMi0yVjZhMiAyIDAgMCAxIDItMmgybTQgN2g0bS00IDVoNG0tOC01aC4wMU04IDE2aC4wMSIvPjwvZz48L3N2Zz4=");
+        }
+    }
+}
+[data-callout][data-callout-type="abstract"] > [data-callout-title]:empty::after {
+    content: "Abstract";
+}
+[data-callout][data-callout-type="summary"] > [data-callout-title]:empty::after {
+    content: "Summary";
+}
+[data-callout][data-callout-type="tldr"] > [data-callout-title]:empty::after {
+    content: "TL;DR";
+}
+[data-callout][data-callout-type="tip"],
+[data-callout][data-callout-type="hint"],
+[data-callout][data-callout-type="important"] {
+    & {
+        @apply border-cyan-600/20 bg-cyan-400/20 dark:border-cyan-800/20 dark:bg-cyan-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-cyan-500;
+        }
+        &::before {
+            /* lucide:flame */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTguNSAxNC41QTIuNSAyLjUgMCAwIDAgMTEgMTJjMC0xLjM4LS41LTItMS0zYy0xLjA3Mi0yLjE0My0uMjI0LTQuMDU0IDItNmMuNSAyLjUgMiA0LjkgNCA2LjVjMiAxLjYgMyAzLjUgMyA1LjVhNyA3IDAgMSAxLTE0IDBjMC0xLjE1My40MzMtMi4yOTQgMS0zYTIuNSAyLjUgMCAwIDAgMi41IDIuNSIvPjwvc3ZnPg==");
+        }
+    }
+}
+[data-callout][data-callout-type="tip"] > [data-callout-title]:empty::after {
+    content: "Tip";
+}
+[data-callout][data-callout-type="hint"] > [data-callout-title]:empty::after {
+    content: "Hint";
+}
+[data-callout][data-callout-type="important"] > [data-callout-title]:empty::after {
+    content: "Important";
+}
+[data-callout][data-callout-type="success"],
+[data-callout][data-callout-type="check"],
+[data-callout][data-callout-type="done"] {
+    & {
+        @apply border-green-600/20 bg-green-400/20 dark:border-green-800/20 dark:bg-green-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-green-500;
+        }
+        &::before {
+            /* lucide:check */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTIwIDZMOSAxN2wtNS01Ii8+PC9zdmc+");
+        }
+    }
+}
+[data-callout][data-callout-type="success"] > [data-callout-title]:empty::after {
+    content: "Success";
+}
+[data-callout][data-callout-type="check"] > [data-callout-title]:empty::after {
+    content: "Check";
+}
+[data-callout][data-callout-type="done"] > [data-callout-title]:empty::after {
+    content: "Done";
+}
+[data-callout][data-callout-type="question"],
+[data-callout][data-callout-type="help"],
+[data-callout][data-callout-type="faq"] {
+    & {
+        @apply border-orange-600/20 bg-orange-400/20 dark:border-orange-800/20 dark:bg-orange-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-orange-500;
+        }
+        &::before {
+            /* lucide:circle-help */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiLz48cGF0aCBkPSJNOS4wOSA5YTMgMyAwIDAgMSA1LjgzIDFjMCAyLTMgMy0zIDNtLjA4IDRoLjAxIi8+PC9nPjwvc3ZnPg==");
+        }
+    }
+}
+[data-callout][data-callout-type="question"] > [data-callout-title]:empty::after {
+    content: "Question";
+}
+[data-callout][data-callout-type="help"] > [data-callout-title]:empty::after {
+    content: "Help";
+}
+[data-callout][data-callout-type="faq"] > [data-callout-title]:empty::after {
+    content: "FAQ";
+}
+[data-callout][data-callout-type="warning"],
+[data-callout][data-callout-type="caution"],
+[data-callout][data-callout-type="attention"] {
+    & {
+        @apply border-orange-600/20 bg-orange-400/20 dark:border-orange-800/20 dark:bg-orange-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-orange-500;
+        }
+        &::before {
+            /* lucide:triangle-alert */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0ibTIxLjczIDE4bC04LTE0YTIgMiAwIDAgMC0zLjQ4IDBsLTggMTRBMiAyIDAgMCAwIDQgMjFoMTZhMiAyIDAgMCAwIDEuNzMtM00xMiA5djRtMCA0aC4wMSIvPjwvc3ZnPg==");
+        }
+    }
+}
+[data-callout][data-callout-type="warning"] > [data-callout-title]:empty::after {
+    content: "Warning";
+}
+[data-callout][data-callout-type="caution"] > [data-callout-title]:empty::after {
+    content: "Caution";
+}
+[data-callout][data-callout-type="attention"] > [data-callout-title]:empty::after {
+    content: "Attention";
+}
+[data-callout][data-callout-type="failure"],
+[data-callout][data-callout-type="fail"],
+[data-callout][data-callout-type="missing"] {
+    & {
+        @apply border-red-600/20 bg-red-400/20 dark:border-red-800/20 dark:bg-red-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-red-500;
+        }
+        &::before {
+            /* lucide:check */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTIwIDZMOSAxN2wtNS01Ii8+PC9zdmc+");
+        }
+    }
+}
+[data-callout][data-callout-type="failure"] > [data-callout-title]:empty::after {
+    content: "Failure";
+}
+[data-callout][data-callout-type="fail"] > [data-callout-title]:empty::after {
+    content: "Fail";
+}
+[data-callout][data-callout-type="missing"] > [data-callout-title]:empty::after {
+    content: "Missing";
+}
+[data-callout][data-callout-type="danger"],
+[data-callout][data-callout-type="error"] {
+    & {
+        @apply border-red-600/20 bg-red-400/20 dark:border-red-800/20 dark:bg-red-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-red-500;
+        }
+        &::before {
+            /* lucide:zap */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXphcCI+PHBhdGggZD0iTTQgMTRhMSAxIDAgMCAxLS43OC0xLjYzbDkuOS0xMC4yYS41LjUgMCAwIDEgLjg2LjQ2bC0xLjkyIDYuMDJBMSAxIDAgMCAwIDEzIDEwaDdhMSAxIDAgMCAxIC43OCAxLjYzbC05LjkgMTAuMmEuNS41IDAgMCAxLS44Ni0uNDZsMS45Mi02LjAyQTEgMSAwIDAgMCAxMSAxNHoiLz48L3N2Zz4=");
+        }
+    }
+}
+[data-callout][data-callout-type="danger"] > [data-callout-title]:empty::after {
+    content: "Danger";
+}
+[data-callout][data-callout-type="error"] > [data-callout-title]:empty::after {
+    content: "Error";
+}
+[data-callout][data-callout-type="bug"] {
+    & {
+        @apply border-red-600/20 bg-red-400/20 dark:border-red-800/20 dark:bg-red-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-red-500;
+        }
+        &::before {
+            /* lucide:bug */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiI+PHBhdGggZD0ibTggMmwxLjg4IDEuODhtNC4yNCAwTDE2IDJNOSA3LjEzdi0xYTMuMDAzIDMuMDAzIDAgMSAxIDYgMHYxIi8+PHBhdGggZD0iTTEyIDIwYy0zLjMgMC02LTIuNy02LTZ2LTNhNCA0IDAgMCAxIDQtNGg0YTQgNCAwIDAgMSA0IDR2M2MwIDMuMy0yLjcgNi02IDZtMCAwdi05Ii8+PHBhdGggZD0iTTYuNTMgOUM0LjYgOC44IDMgNy4xIDMgNW0zIDhIMm0xIDhjMC0yLjEgMS43LTMuOSAzLjgtNE0yMC45NyA1YzAgMi4xLTEuNiAzLjgtMy41IDRNMjIgMTNoLTRtLS44IDRjMi4xLjEgMy44IDEuOSAzLjggNCIvPjwvZz48L3N2Zz4=");
+        }
+    }
+}
+[data-callout][data-callout-type="bug"] > [data-callout-title]:empty::after {
+    content: "Bug";
+}
+[data-callout][data-callout-type="example"] {
+    & {
+        @apply border-purple-600/20 bg-purple-400/20 dark:border-purple-800/20 dark:bg-purple-600/10;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-purple-500;
+        }
+        &::before {
+            /* lucide:list */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTggNmgxM004IDEyaDEzTTggMThoMTNNMyA2aC4wMU0zIDEyaC4wMU0zIDE4aC4wMSIvPjwvc3ZnPg==");
+        }
+    }
+}
+[data-callout][data-callout-type="example"] > [data-callout-title]:empty::after {
+    content: "Example";
+}
+[data-callout][data-callout-type="quote"],
+[data-callout][data-callout-type="cite"] {
+    & {
+        @apply border-zinc-600/20 bg-zinc-400/20 dark:border-zinc-800/20 dark:bg-zinc-600/15;
+    }
+    & > [data-callout-title] {
+        & {
+            @apply text-zinc-500;
+        }
+        &::before {
+            /* lucide:quote */
+            mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTMgMjFjMyAwIDctMSA3LThWNWMwLTEuMjUtLjc1Ni0yLjAxNy0yLTJINGMtMS4yNSAwLTIgLjc1LTIgMS45NzJWMTFjMCAxLjI1Ljc1IDIgMiAyYzEgMCAxIDAgMSAxdjFjMCAxLTEgMi0yIDJzLTEgLjAwOC0xIDEuMDMxVjIwYzAgMSAwIDEgMSAxbTEyIDBjMyAwIDctMSA3LThWNWMwLTEuMjUtLjc1Ny0yLjAxNy0yLTJoLTRjLTEuMjUgMC0yIC43NS0yIDEuOTcyVjExYzAgMS4yNS43NSAyIDIgMmguNzVjMCAyLjI1LjI1IDQtMi43NSA0djNjMCAxIDAgMSAxIDEiLz48L3N2Zz4=");
+        }
+    }
+}
+[data-callout][data-callout-type="quote"] > [data-callout-title]:empty::after {
+    content: "Quote";
+}
+[data-callout][data-callout-type="cite"] > [data-callout-title]:empty::after {
+    content: "Cite";
+}

--- a/apps/blog/svelte.config.js
+++ b/apps/blog/svelte.config.js
@@ -5,6 +5,8 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 import rehypeToc from "rehype-toc";
 import remarkGfm from "remark-gfm";
+import remarkCallout from "@r4ai/remark-callout";
+import remarkCalloutFix from "./remark-callout-fix.js";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { join } from "node:path";
 
@@ -14,7 +16,7 @@ const rehypeTocOpts = { position: "beforeend" };
 const mdsvexConfig = {
     extension: ".mdx",
     layout: join(import.meta.dirname, "src/layouts/article.svelte"),
-    remarkPlugins: [remarkGfm],
+    remarkPlugins: [remarkCalloutFix, remarkCallout, remarkGfm],
     rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings, [rehypeToc, rehypeTocOpts]],
 };
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "type": "module",
   "dependencies": {
     "@lucide/svelte": "^0.553.0",
+    "@r4ai/remark-callout": "^0.6.2",
     "@vercel/speed-insights": "^1.2.0",
     "bits-ui": "^2.8.10",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@lucide/svelte':
         specifier: ^0.553.0
         version: 0.553.0(svelte@5.43.5)
+      '@r4ai/remark-callout':
+        specifier: ^0.6.2
+        version: 0.6.2
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.5)(vite@7.2.2(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.43.5)(vite@7.2.2(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.43.5)
@@ -437,6 +440,10 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@r4ai/remark-callout@0.6.2':
+    resolution: {integrity: sha512-yRj0dzEqdGYquJqTcr68CtAAh47AamWGMbZwiXBTeH6tf2MAh3Rc8C3xYhsRHKX91j9h5JZPTV2YLv+zL08AHQ==}
+    engines: {node: '>=16'}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1037,6 +1044,9 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2529,6 +2539,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@r4ai/remark-callout@0.6.2':
+    dependencies:
+      defu: 6.1.7
+      unist-util-visit: 5.0.0
+
   '@rollup/pluginutils@5.3.0(rollup@4.53.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -3085,6 +3100,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  defu@6.1.7: {}
 
   dequal@2.0.3: {}
 


### PR DESCRIPTION
## Description

Got things working quite well for supporting callout syntax:

<img width="1512" height="982" alt="callout-demo" src="https://github.com/user-attachments/assets/e9a6d947-b119-4bdf-9459-b990ba4d0fc3" />

## Missing Functionality

- Does not support foldable callouts, like

  ```md
  > [!note]- title here
  > body here
  ```
- Does not support callout titles, like

  ```md
  > [!note] Custom Title Here
  > body here
  ```

Both these bugs are due to [`remark-callout` compatibility with `mdsvex`](https://github.com/pngwn/MDsveX/issues/737), and me having to introduce a custom patch remark plugin to get things working whatsoever.

The funny thing is, while I love both of these features, and they're supported in Obsidian, [GitHub Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) don't support them, so I ironically made GitHub-compatible callout syntax, so I may not have motivation to fix this anytime soon.