### PR TITLE
feat(blog): add footnote support

### DIFF
--- a/apps/blog/svelte.config.js
+++ b/apps/blog/svelte.config.js
@@ -4,6 +4,7 @@ import { importAssets } from "svelte-preprocess-import-assets";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 import rehypeToc from "rehype-toc";
+import remarkFootnotes from "remark-footnotes";
 import remarkGfm from "remark-gfm";
 import remarkCallout from "@r4ai/remark-callout";
 import remarkCalloutFix from "./remark-callout-fix.js";
@@ -12,11 +13,22 @@ import { join } from "node:path";
 
 const rehypeTocOpts = { position: "beforeend" };
 
+// `remark-footnotes` pinned to v2 only, as v3+ uses micromark and
+// won't hook into mdsvex's remark-parse v8.
+// TODO: Move away from mdsvex, as it hasn't had an update for a year+
+// TODO: and is the root of many issues with TOC and callouts.
+const remarkFootnotesOpts = { inlineNotes: true };
+
 /** @type {import('mdsvex').MdsvexOptions} */
 const mdsvexConfig = {
     extension: ".mdx",
     layout: join(import.meta.dirname, "src/layouts/article.svelte"),
-    remarkPlugins: [remarkCalloutFix, remarkCallout, remarkGfm],
+    remarkPlugins: [
+        remarkCalloutFix,
+        remarkCallout,
+        [remarkFootnotes, remarkFootnotesOpts],
+        remarkGfm,
+    ],
     rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings, [rehypeToc, rehypeTocOpts]],
 };
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "rehype-toc": "^3.0.2",
+    "remark-footnotes": "2.0.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.4.0",
     "tailwind-variants": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       rehype-toc:
         specifier: ^3.0.2
         version: 3.0.2
+      remark-footnotes:
+        specifier: 2.0.0
+        version: 2.0.0
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
@@ -1858,6 +1861,9 @@ packages:
   rehype-toc@3.0.2:
     resolution: {integrity: sha512-DMt376+4i1KJGgHJL7Ezd65qKkJ7Eqp6JSB47BJ90ReBrohI9ufrornArM6f4oJjP2E2DVZZHufWucv/9t7GUQ==}
     engines: {node: '>=10'}
+
+  remark-footnotes@2.0.0:
+    resolution: {integrity: sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3994,6 +4000,8 @@ snapshots:
   rehype-toc@3.0.2:
     dependencies:
       '@jsdevtools/rehype-toc': 3.0.2
+
+  remark-footnotes@2.0.0: {}
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Description

Add markdown footnote support to the blog.

Implementation is a tad odd, all rooting back to connected dependencies. MDsveX does not use [`micromark`](https://github.com/micromark/micromark), and hasn't been updated in over a year (looks like it won't support it. Along with the other weirdness and headaches MDsveX has caused relating to callout and table-of-contents support, it also inhibits [`remark-gfm`](https://github.com/remarkjs/remark-gfm) (a dependency already in use by this repo) from properly supporting footnotes, which it should natively be able to display. `remark-gfm` supports footnotes by hooking into the `micromark` parser, which isn't supported by MDsveX. To fix this until I upgrade my markdown preprocessing system, I'm using 2 majors back on the deprecated [`remark-footnotes`](https://github.com/remarkjs/remark-footnotes) package to support the non-micromark implementation.

## Demo

### Footnote Reference

<img width="623" height="233" alt="footnote-reference" src="https://github.com/user-attachments/assets/8cfb26d4-d196-4377-aada-4c4a49eac302" />

### Footnote Content

<img width="633" height="280" alt="footnote-content" src="https://github.com/user-attachments/assets/c7e7b9b9-6d2b-4119-baa3-c06030e8f4f9" />
