### PR TITLE
feat(blog): pretty text wrap on article cards

### DIFF
--- a/apps/blog/src/routes/+page.svelte
+++ b/apps/blog/src/routes/+page.svelte
@@ -35,14 +35,14 @@
         </h1>
         <Separator />
         <ScrollArea
-            class="mx-1 h-[calc(91vh-17rem)] rounded-md text-lg backdrop-blur-xs sm:float-right sm:h-[calc(85vh-18rem)] sm:max-w-sm sm:text-right"
+            class="mx-1 h-[calc(90svh-14rem)] rounded-md text-lg backdrop-blur-xs sm:float-right sm:h-[calc(85vh-18rem)] sm:max-w-sm sm:text-right"
             scrollbarYClasses="hidden"
         >
             <div class="space-y-2">
                 {#each articles as article (article.filePath)}
                     <Card.Root class="opacity-90">
                         <a href={getFilenameFromPath(article.filePath)}>
-                            <Card.Header class="pb-3">
+                            <Card.Header class="pb-3 text-pretty">
                                 <Card.Title class="font-medium tracking-[0.023em]">
                                     {article.metadata.title}
                                 </Card.Title>

--- a/apps/lib/app.css
+++ b/apps/lib/app.css
@@ -34,7 +34,7 @@
 
 /* Ensure screen height is consistent across mobile and desktop, with no scrollbars */
 @utility screen-height {
-    @apply h-[100svh] sm:h-screen;
+    @apply h-svh sm:h-screen;
 }
 
 @utility binary-text-overlay {


### PR DESCRIPTION
## Description

Switch to [`text-wrap: pretty`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-wrap#pretty), which has many benefits over [`text-wrap: wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-wrap#wrap), but namely fixes the issue of having one single word split to and hanging on the next line (see demo for before/after examples).

Additionally: Tiny Tailwind class name refactor to use built-in classname instead of custom unit specification.

## Demo

### Before

<img width="443" height="247" alt="title-before" src="https://github.com/user-attachments/assets/9663b6d4-22b8-4404-a6e8-347e5b2d05fa" />

<img width="442" height="248" alt="description-before" src="https://github.com/user-attachments/assets/8ea8179a-ab92-4606-ba55-965953c3da59" />

### After

<img width="442" height="252" alt="title-after" src="https://github.com/user-attachments/assets/54c2f5f6-6d04-4540-b2d1-00befad2c541" />

<img width="438" height="247" alt="description-after" src="https://github.com/user-attachments/assets/5b0bb75f-6edb-4258-9e13-2326c0451675" />