### PR TITLE
Blog Content Presentation Fixes

### DIFF
--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -28,7 +28,7 @@ h4 {
 }
 
 .toc {
-    @apply hidden p-3 sm:block sm:basis-1/4;
+    @apply ml-4 hidden p-3 sm:block sm:basis-1/4;
 }
 
 .toc-link {

--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -48,3 +48,10 @@ h4 {
 nav > :last-child.toc-level {
     @apply mb-0;
 }
+
+/* Break anywhere for inline code (excluding `pre` blocks) to not introduce */
+/* horizontal scroll. `:not(pre) > code` skips code inside pre, while       */
+/* `:where()` keeps specificity low so prose styles win.                    */
+.prose :where(:not(pre) > code) {
+    overflow-wrap: anywhere;
+}

--- a/apps/blog/src/layouts/article.svelte
+++ b/apps/blog/src/layouts/article.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <main class="font-sans sm:basis-3/4">
-    <article class="prose dark:prose-invert mr-4 max-w-3xl text-pretty">
+    <article class="prose dark:prose-invert max-w-3xl text-pretty">
         {@render children?.()}
     </article>
 </main>


### PR DESCRIPTION
## Description

- Fix bug on mobile (or any layout that hides the table of contents) where a very small amount of extra margin was applied to the right side of blog content. Moved the right margin from the article content to a left margin on the table of contents component to keep desired functionality only (desktop looks the same as before; mobile now has even padding on both sides).
- Fix bug on narrow screens where long non-breakable text overflowed the viewport, introducing horizontal scrolling (see screenshot). Added support to split anywhere within inline code so things like long URLs won't introduce horizontal scrolling.

  ![x-overflow-issue](https://github.com/user-attachments/assets/8d72cf08-72a8-4f34-9e13-2fb5568048cb)

