### PR TITLE
refactor(blog): de-duplicate article loading logic

### DIFF
--- a/apps/blog/src/routes/+page.svelte
+++ b/apps/blog/src/routes/+page.svelte
@@ -8,11 +8,6 @@
     let { data } = $props();
 
     const { articles } = data;
-
-    const getFilenameFromPath = (filePath: string): string | null => {
-        const filenameWithExtension = filePath.split("/").pop();
-        return filenameWithExtension?.split(".").slice(0, -1).join(".") || null;
-    };
 </script>
 
 <SiteMeta
@@ -40,9 +35,9 @@
             scrollbarYClasses="hidden"
         >
             <div class="space-y-2">
-                {#each articles as article (article.filePath)}
+                {#each articles as article (article.slug)}
                     <Card.Root class="opacity-90">
-                        <a href={getFilenameFromPath(article.filePath)}>
+                        <a href={article.slug}>
                             <Card.Header class="pb-3 text-pretty">
                                 <Card.Title class="font-medium tracking-[0.023em]">
                                     {article.metadata.title}

--- a/apps/blog/src/routes/+page.ts
+++ b/apps/blog/src/routes/+page.ts
@@ -1,28 +1,13 @@
 /**
  * This file loads metadata and filenames for all blog articles in the `content` directory.
  */
-import type MdxSvelteComponent from "$lib/MdxSvelteComponent";
+import { loadArticles } from "$lib/articles";
 
 export const prerender = true;
 
 /** @type {import('./$types.js').PageLoad} */
 export async function load() {
-    const imports = import.meta.glob("../../content/*.mdx");
-    const fileMetadata = [];
-
-    try {
-        for (const importPath in imports) {
-            const articleFile = await (imports[importPath]() as Promise<MdxSvelteComponent>);
-            fileMetadata.push({
-                filePath: importPath,
-                metadata: articleFile.metadata,
-            });
-        }
-    } catch {
-        console.error("Could not find article");
-    }
-
     return {
-        articles: fileMetadata,
+        articles: await loadArticles(),
     };
 }


### PR DESCRIPTION
## Description

- De-duplicate article loading and slug parsing logic. Reuses new code from:
  - #133
- Technically, this isn't a true refactor, as some behaviour is different now, but I'll still call it a refactor as the change is quite minimal IMO. The change in behaviour here is that articles are now listed in reverse chronological order by last-modified date, instead of lexicographically.

---

Follow-up to #133