### PR TITLE
fix(blog): heading links overflow viewport on mobile

### DIFF
--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -5,18 +5,21 @@
 
 @plugin "@tailwindcss/typography";
 
-span.icon-link::before {
+span.icon-link::after {
     content: "#";
     color: hsl(var(--accent));
-    position: absolute;
-    left: -23px;
+    margin-left: 8px;
     opacity: 0;
     transition: opacity 0.3s ease;
 }
 
-h2:hover span.icon-link::before,
-h3:hover span.icon-link::before,
-h4:hover span.icon-link::before {
+a:has(> span.icon-link) {
+    text-decoration: none;
+}
+
+h2:hover span.icon-link::after,
+h3:hover span.icon-link::after,
+h4:hover span.icon-link::after {
     opacity: 1;
 }
 

--- a/apps/blog/svelte.config.js
+++ b/apps/blog/svelte.config.js
@@ -14,6 +14,7 @@ import { importAssets } from "svelte-preprocess-import-assets";
 import remarkCalloutFix from "./remark-callout-fix.js";
 
 const rehypeTocOpts = { position: "beforeend" };
+const rehypeAutoLinkHeadingsOpts = { behavior: "append" };
 
 // `remark-footnotes` pinned to v2 only, as v3+ uses micromark and
 // won't hook into mdsvex's remark-parse v8.
@@ -31,7 +32,11 @@ const mdsvexConfig = {
         [remarkFootnotes, remarkFootnotesOpts],
         remarkGfm,
     ],
-    rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings, [rehypeToc, rehypeTocOpts]],
+    rehypePlugins: [
+        rehypeSlug,
+        [rehypeAutolinkHeadings, rehypeAutoLinkHeadingsOpts],
+        [rehypeToc, rehypeTocOpts],
+    ],
 };
 
 /** @type {import('@sveltejs/kit').Config} */


### PR DESCRIPTION
## Description

On mobile, heading links barely go off the left of the screen, due to absolute positioning.

There's no super clean way to fix this, so I opted to simply move the heading link to the right of the heading text instead of the left. I honestly prefer the look of being to the left of the heading on desktop, but to the right on mobile, but since we're doing this with a rehype plugin, I don't want to mess with anything weird for now; maybe I'll make it dynamic in the future. Still looks great.

## Demo

| Before | After |
| --- | --- |
| ![before-mobile](https://github.com/user-attachments/assets/86f1bbb9-3cb6-45d9-b5df-c7ded66c40a0) | ![after-mobile](https://github.com/user-attachments/assets/ec5ca5ab-8e75-408b-b661-0d87833e0098) |
| ![before-desktop](https://github.com/user-attachments/assets/9224f12e-2c90-4444-a708-5748832b6650) | ![after-desktop](https://github.com/user-attachments/assets/4867d0d1-d213-4e93-9fab-7d41fbe96b40) |

