### PR TITLE
fix(blog): look nice at medium breakpoints

### DIFF
--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -30,7 +30,7 @@ h4 {
 }
 
 .toc {
-    @apply ml-4 hidden p-3 sm:block sm:basis-1/4;
+    @apply ml-4 hidden shrink-0 p-3 sm:block sm:basis-1/4;
 }
 
 .toc-link {

--- a/apps/blog/src/layouts/article.svelte
+++ b/apps/blog/src/layouts/article.svelte
@@ -6,8 +6,8 @@
     let { children }: Props = $props();
 </script>
 
-<main class="font-sans sm:basis-3/4">
-    <article class="prose dark:prose-invert max-w-3xl text-pretty">
+<main class="min-w-0 font-sans sm:basis-3/4">
+    <article class="prose dark:prose-invert w-full max-w-3xl min-w-0 text-pretty">
         {@render children?.()}
     </article>
 </main>

--- a/apps/blog/src/routes/[slug=metapage]/+page.svelte
+++ b/apps/blog/src/routes/[slug=metapage]/+page.svelte
@@ -52,7 +52,7 @@
     {tags}
 />
 <Header />
-<header class="mx-5 my-7 space-y-3 font-medium sm:mx-48" id="article-header">
+<header class="mx-5 my-7 space-y-3 font-medium sm:mx-16 md:mx-32 lg:mx-48" id="article-header">
     <Tags {tags} />
     <h1 class="text-4xl">{title}</h1>
     <div class="flex space-x-2">
@@ -64,14 +64,14 @@
     </div>
 </header>
 <Separator />
-<div class="mx-5 my-6 sm:mx-48">
+<div class="mx-5 my-6 sm:mx-16 md:mx-32 lg:mx-48">
     <p class="font-medium">{description}</p>
 </div>
 <Separator />
 <div
     in:fade|global={{ delay: 150, duration: 350 }}
     out:fade|global={{ duration: 100 }}
-    class="m-5 mt-7 mb-10 sm:mx-60 sm:flex sm:flex-row"
+    class="m-5 mt-7 mb-10 min-w-0 sm:mx-16 sm:flex sm:flex-row md:mx-32 lg:mx-60"
 >
     <data.mdxComponent />
 </div>


### PR DESCRIPTION
## Description

Ensure blog content is legible and pleasant to read on awkward screen resolutions, including things like iPads, tablets, sideways iPhones, etc.

## Demo

| Before | After |
| --- | --- |
| ![mbp14-half-screen-before](https://github.com/user-attachments/assets/2c54abfd-5bae-49c1-a02d-4ea7ccd4c7a8) | ![mbp14-half-screen-after](https://github.com/user-attachments/assets/277e6183-3273-4b8b-8eea-5c6d88317a2f) |
| ![iphone-sideways-before](https://github.com/user-attachments/assets/81f814b0-0a56-494e-add0-d34b9c83698d) | ![iphone-sideways-after](https://github.com/user-attachments/assets/c0115f8b-ebfb-4164-b10a-4430ae2ab0a9) |

---

closes #159
