### PR TITLE
fix(blog): centre + constrain content on ultrawide screens

### DIFF
--- a/apps/blog/src/lib/header.svelte
+++ b/apps/blog/src/lib/header.svelte
@@ -41,47 +41,49 @@
     });
 </script>
 
-<div
-    bind:this={header}
-    class="top-0 left-0 z-50 flex w-full items-center justify-between bg-stone-100 px-3 py-2 sm:px-4 dark:bg-stone-900"
->
-    <div class="flex items-center space-x-6">
-        <a href="/">
-            {#if mode.current === "dark"}
-                <img src={logoLight} alt="Logo Light" class="h-11" />
-            {:else}
-                <img src={logoDark} alt="Logo Dark" class="h-11" />
-            {/if}
-        </a>
-        <div
-            class="hidden items-center space-x-6 *:transition-all *:ease-in-out *:hover:transition-all *:hover:ease-in-out *:hover:text-shadow-6xl sm:flex"
-        >
-            {#each siteLinksEntries() as [title, link] (link)}
-                <p class="text-xl font-semibold">
-                    <a href={link}>{title}</a>
-                </p>
-            {/each}
+<div bind:this={header} class="top-0 left-0 z-50 w-full bg-stone-100 dark:bg-stone-900">
+    <div class="site-container flex items-center justify-between px-3 py-2 sm:px-4">
+        <div class="flex items-center space-x-6">
+            <a href="/">
+                {#if mode.current === "dark"}
+                    <img src={logoLight} alt="Logo Light" class="h-11" />
+                {:else}
+                    <img src={logoDark} alt="Logo Dark" class="h-11" />
+                {/if}
+            </a>
+            <div
+                class="hidden items-center space-x-6 *:transition-all *:ease-in-out *:hover:transition-all *:hover:ease-in-out *:hover:text-shadow-6xl sm:flex"
+            >
+                {#each siteLinksEntries() as [title, link] (link)}
+                    <p class="text-xl font-semibold">
+                        <a href={link}>{title}</a>
+                    </p>
+                {/each}
+            </div>
         </div>
-    </div>
-    <div class="hidden items-center space-x-2 px-2 sm:flex">
-        <ThemeToggle variant="ghost" />
-        <Socials imageSize="25px" class="space-x-3" />
-    </div>
+        <div class="hidden items-center space-x-2 px-2 sm:flex">
+            <ThemeToggle variant="ghost" />
+            <Socials imageSize="25px" class="space-x-3" />
+        </div>
 
-    <Drawer.Root direction="top">
-        <Drawer.Trigger>
-            {#snippet child({ props })}
-                <div {...props} class={cn(buttonVariants({ variant: "ghost" }), "p-1 sm:hidden")}>
-                    <Menu
-                        color={mode.current === "dark" ? "#EEE" : "#111"}
-                        size="28"
-                        strokeWidth="2.5"
-                        class="m-1"
-                    />
-                </div>
-            {/snippet}
-        </Drawer.Trigger>
-        <HeaderDrawerContent />
-    </Drawer.Root>
+        <Drawer.Root direction="top">
+            <Drawer.Trigger>
+                {#snippet child({ props })}
+                    <div
+                        {...props}
+                        class={cn(buttonVariants({ variant: "ghost" }), "p-1 sm:hidden")}
+                    >
+                        <Menu
+                            color={mode.current === "dark" ? "#EEE" : "#111"}
+                            size="28"
+                            strokeWidth="2.5"
+                            class="m-1"
+                        />
+                    </div>
+                {/snippet}
+            </Drawer.Trigger>
+            <HeaderDrawerContent />
+        </Drawer.Root>
+    </div>
 </div>
 <div bind:this={spacer} class="top-0 left-0 hidden h-16 w-full"></div>

--- a/apps/blog/src/routes/[slug=metapage]/+page.svelte
+++ b/apps/blog/src/routes/[slug=metapage]/+page.svelte
@@ -52,27 +52,29 @@
     {tags}
 />
 <Header />
-<header class="mx-5 my-7 space-y-3 font-medium sm:mx-16 md:mx-32 lg:mx-48" id="article-header">
-    <Tags {tags} />
-    <h1 class="text-4xl">{title}</h1>
-    <div class="flex space-x-2">
-        <p>By {author}</p>
-        <p>•</p>
-        <button onclick={computeDateMessage} class="cursor-pointer">
-            {dateMessage}
-        </button>
+<div class="site-container">
+    <header class="mx-5 my-7 space-y-3 font-medium sm:mx-16 md:mx-32 lg:mx-48" id="article-header">
+        <Tags {tags} />
+        <h1 class="text-4xl">{title}</h1>
+        <div class="flex space-x-2">
+            <p>By {author}</p>
+            <p>•</p>
+            <button onclick={computeDateMessage} class="cursor-pointer">
+                {dateMessage}
+            </button>
+        </div>
+    </header>
+    <Separator />
+    <div class="mx-5 my-6 sm:mx-16 md:mx-32 lg:mx-48">
+        <p class="font-medium">{description}</p>
     </div>
-</header>
-<Separator />
-<div class="mx-5 my-6 sm:mx-16 md:mx-32 lg:mx-48">
-    <p class="font-medium">{description}</p>
-</div>
-<Separator />
-<div
-    in:fade|global={{ delay: 150, duration: 350 }}
-    out:fade|global={{ duration: 100 }}
-    class="m-5 mt-7 mb-10 min-w-0 sm:mx-16 sm:flex sm:flex-row md:mx-32 lg:mx-60"
->
-    <data.mdxComponent />
+    <Separator />
+    <div
+        in:fade|global={{ delay: 150, duration: 350 }}
+        out:fade|global={{ duration: 100 }}
+        class="m-5 mt-7 mb-10 min-w-0 sm:mx-16 sm:flex sm:flex-row md:mx-32 lg:mx-60"
+    >
+        <data.mdxComponent />
+    </div>
 </div>
 <Footer />

--- a/packages/ui/app.css
+++ b/packages/ui/app.css
@@ -8,6 +8,11 @@
 @theme {
     --font-serif: "IM Fell English", "serif";
     --font-sans: "Hind", "sans";
+    --max-width-site: 1700px;
+}
+
+@utility site-container {
+    @apply mx-auto w-full max-w-site;
 }
 
 @layer base {

--- a/packages/ui/components/Footer.svelte
+++ b/packages/ui/components/Footer.svelte
@@ -3,25 +3,27 @@
     const date = `2022–${new Date().getFullYear()}`;
 </script>
 
-<footer class="space-y-6 bg-stone-100 dark:bg-stone-900">
-    <pre class="pt-6 text-center leading-4 tracking-[-0.125em]">
+<footer class="bg-stone-100 dark:bg-stone-900">
+    <div class="site-container space-y-6">
+        <pre class="pt-6 text-center leading-4 tracking-[-0.125em]">
 ⠀⣀⣤⡀⠀⠀⢀⣀⠀⢀⡤⣄⡀⢀⣀⣠⣤⣤⣄⣀⠀⠀⠀⢀⣀⣤⣤⣤⣀⣀⠀⣠⡤⡄⠀⢀⡀⠀⠀⢀⣠⣄⡀
 ⢸⠋⢠⡽⠀⣴⠋⢩⣿⢈⣡⡽⠿⠿⠛⣩⠴⠒⠒⠺⣷⣻⣷⠿⠒⠒⠢⣭⡙⠻⠿⠿⣤⡁⢼⣫⠙⢷⡀⢸⡧⠈⢳
 ⠘⢦⡀⠀⠀⢧⣀⡼⠿⠋⠁⠀⣠⡴⠋⠁⠀⠀⠀⠀⠈⣿⡇⠀⠀⠀⠀⠀⠙⠳⣄⡀⠀⠙⠻⢧⣄⣸⠃⠀⢀⣠⠏
 ⠀⠀⠀⠉⠉⠉⠓⠤⠤⠤⠴⠛⠁⠀⠀⠀⠀⠸⣟⣀⡼⣿⢷⣄⣛⡵⠀⠀⠀⠀⠈⠙⠲⠤⠤⠤⠜⠋⠉⠉⠁⠀⠀
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠹⠷⣿⠷⠏⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</pre>
-    <!-- TODO: Replace these two lines with spinning 3js animation. -->
-    <!-- TODO: For now, desktop- and mobile-specific versions b/c hearts -->
-    <!-- TODO: render slightly different on commonm mobile browsers. -->
-    <p class="px-6 text-right sm:hidden">₊˚⊹ Made with ❤ by Cameron.</p>
-    <p class="hidden px-6 text-right sm:block sm:px-12">₊˚⊹ Made with ♥ by Cameron.</p>
+        <!-- TODO: Replace these two lines with spinning 3js animation. -->
+        <!-- TODO: For now, desktop- and mobile-specific versions b/c hearts -->
+        <!-- TODO: render slightly different on commonm mobile browsers. -->
+        <p class="px-6 text-right sm:hidden">₊˚⊹ Made with ❤ by Cameron.</p>
+        <p class="hidden px-6 text-right sm:block sm:px-12">₊˚⊹ Made with ♥ by Cameron.</p>
 
-    <div class="space-y-2 px-6 pb-6 sm:px-12">
-        <p>{`Copyright © ${date} Cameron Ball. All rights reserved.`}</p>
-        <p>
-            Opinions on this site are my own and are not those of any of my employers, past,
-            present, and/or future.
-        </p>
+        <div class="space-y-2 px-6 pb-6 sm:px-12">
+            <p>{`Copyright © ${date} Cameron Ball. All rights reserved.`}</p>
+            <p>
+                Opinions on this site are my own and are not those of any of my employers, past,
+                present, and/or future.
+            </p>
+        </div>
     </div>
 </footer>


### PR DESCRIPTION
## Description

Ensure blog content is centred, and site elements like header/footer are constrained on wide screen sizes. The site should look great even displayed in full-screen on a 49" monitor.

## Demo

| Before | After |
| --- | --- |
| ![wide-before](https://github.com/user-attachments/assets/3feacd7f-bc56-425a-a5ef-65937b99f2da) | ![wide-after](https://github.com/user-attachments/assets/982b1169-533c-40eb-b414-8a60c0b44111) |
| ![ultrawide-before](https://github.com/user-attachments/assets/22aac14c-8982-46e5-ba32-2c3d9889d848) | ![ultrawide-after](https://github.com/user-attachments/assets/c18cd859-9254-427b-b4e9-1c946d5aad0e) |

---

closes #160