### PR TITLE
fix(blog): stale article metadata on self-referential navigation

### DIFF
--- a/apps/archive/src/components/Loaders/Jellyfish.svelte
+++ b/apps/archive/src/components/Loaders/Jellyfish.svelte
@@ -19,8 +19,9 @@
         size = "60",
         pause = false,
     }: Props = $props();
-    let durationUnit: string = duration.match(durationUnitRegex)?.[0] ?? "s";
-    let durationNum: string = duration.replace(durationUnitRegex, "");
+
+    const durationUnit = $derived(duration.match(durationUnitRegex)?.[0] ?? "s");
+    const durationNum = $derived(duration.replace(durationUnitRegex, ""));
 </script>
 
 <div

--- a/apps/blog/src/components/ArticleDate.svelte
+++ b/apps/blog/src/components/ArticleDate.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import dayjs from "dayjs";
+    import advancedFormat from "dayjs/plugin/advancedFormat";
+
+    let { created, modified }: { created: string; modified: string } = $props();
+
+    dayjs.extend(advancedFormat);
+    const formatDate = (date: Date) => dayjs(date).add(1, "days").format("MMMM Do, YYYY");
+
+    let mode = $state<"initial" | "created" | "modified">("initial");
+
+    const dateMessage = $derived.by(() => {
+        const dateCreated = new Date(created);
+        const dateModified = new Date(modified);
+
+        if (mode === "modified") {
+            return `Last modified ${formatDate(dateModified)}`;
+        }
+
+        if (mode === "created") {
+            return `Created ${formatDate(dateCreated)}`;
+        }
+
+        return formatDate(dateCreated);
+    });
+
+    const computeDateMessage = () => {
+        mode = mode === "modified" ? "created" : "modified";
+    };
+</script>
+
+<button onclick={computeDateMessage} class="cursor-pointer">
+    {dateMessage}
+</button>

--- a/apps/blog/src/routes/+page.svelte
+++ b/apps/blog/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 
     let { data } = $props();
 
-    const { articles } = data;
+    const articles = $derived(data.articles);
 </script>
 
 <SiteMeta

--- a/apps/blog/src/routes/[slug=metapage]/+page.svelte
+++ b/apps/blog/src/routes/[slug=metapage]/+page.svelte
@@ -2,10 +2,9 @@
     import Header from "$lib/header.svelte";
     import { Footer, SiteMeta } from "@camball/ui/components";
     import { Separator } from "@camball/ui/components/ui";
-    import dayjs from "dayjs";
-    import advancedFormat from "dayjs/plugin/advancedFormat";
     import { fade } from "svelte/transition";
 
+    import ArticleDate from "../../components/ArticleDate.svelte";
     import Tags from "../../components/Tags.svelte";
     import type { PageData } from "./$types";
 
@@ -18,55 +17,33 @@
 
     let { data }: Props = $props();
 
-    const { title, author, description, created, modified, tags } = data.metadata;
-
-    dayjs.extend(advancedFormat);
-    const formatDate = (date: Date) => dayjs(date).add(1, "days").format("MMMM Do, YYYY");
-
-    const dateCreated = new Date(created);
-    const dateModified = new Date(modified);
-
-    let dateDisplayed = dateCreated;
-
-    const CREATED = "Created";
-    const LAST_MODIFIED = "Last modified";
-    let dateMessage = $state(formatDate(dateDisplayed));
-
-    const computeDateMessage = () => {
-        if (dateDisplayed === dateCreated) {
-            dateDisplayed = dateModified;
-            dateMessage = `${LAST_MODIFIED} ${formatDate(dateDisplayed)}`;
-        } else {
-            dateDisplayed = dateCreated;
-            dateMessage = `${CREATED} ${formatDate(dateDisplayed)}`;
-        }
-    };
+    const metadata = $derived(data.metadata);
 </script>
 
 <SiteMeta
-    {title}
-    {description}
+    title={metadata.title}
+    description={metadata.description}
     url={`https://blog.camball.io/${data.slug}`}
     siteName="Blog – Cameron Ball"
     type="article"
-    {tags}
+    tags={metadata.tags}
 />
 <Header />
 <div class="site-container">
     <header class="mx-5 my-7 space-y-3 font-medium sm:mx-16 md:mx-32 lg:mx-48" id="article-header">
-        <Tags {tags} />
-        <h1 class="text-4xl">{title}</h1>
+        <Tags tags={metadata.tags} />
+        <h1 class="text-4xl">{metadata.title}</h1>
         <div class="flex space-x-2">
-            <p>By {author}</p>
+            <p>By {metadata.author}</p>
             <p>•</p>
-            <button onclick={computeDateMessage} class="cursor-pointer">
-                {dateMessage}
-            </button>
+            {#key data.slug}
+                <ArticleDate created={metadata.created} modified={metadata.modified} />
+            {/key}
         </div>
     </header>
     <Separator />
     <div class="mx-5 my-6 sm:mx-16 md:mx-32 lg:mx-48">
-        <p class="font-medium">{description}</p>
+        <p class="font-medium">{metadata.description}</p>
     </div>
     <Separator />
     <div

--- a/packages/ui/components/ui/carousel/carousel.svelte
+++ b/packages/ui/components/ui/carousel/carousel.svelte
@@ -23,16 +23,22 @@
         api: undefined,
         scrollPrev,
         scrollNext,
-        orientation,
+        orientation: "horizontal",
         canScrollNext: false,
         canScrollPrev: false,
         handleKeyDown,
-        options: opts,
-        plugins,
+        options: {},
+        plugins: [],
         onInit,
         scrollSnaps: [],
         selectedIndex: 0,
         scrollTo,
+    });
+
+    $effect.pre(() => {
+        carouselState.orientation = orientation;
+        carouselState.options = opts;
+        carouselState.plugins = plugins;
     });
 
     setEmblaContext(carouselState);


### PR DESCRIPTION
## Description

All `svelte-check` warnings for all repos fixed in this PR. All warnings had the same root cause, which was that state wasn't being derived properly and stale state was being used, not letting components know when to re-render.

## Blog `svelte-check` Before/After

```text
Loading svelte-check in workspace: /Users/cameron/code/camball.io/apps/blog
Getting Svelte diagnostics...

/Users/cameron/code/camball.io/apps/blog/../../packages/ui/components/ui/carousel/carousel.svelte:26:9
Warn: This reference only captures the initial value of `orientation`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally (svelte)
        scrollNext,
        orientation,
        canScrollNext: false,

/Users/cameron/code/camball.io/apps/blog/../../packages/ui/components/ui/carousel/carousel.svelte:30:18
Warn: This reference only captures the initial value of `opts`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally (svelte)
        handleKeyDown,
        options: opts,
        plugins,

/Users/cameron/code/camball.io/apps/blog/../../packages/ui/components/ui/carousel/carousel.svelte:31:9
Warn: This reference only captures the initial value of `plugins`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally (svelte)
        options: opts,
        plugins,
        onInit,

/Users/cameron/code/camball.io/apps/blog/src/routes/+page.svelte:11:26
Warn: This reference only captures the initial value of `data`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally (svelte)

    const { articles } = data;
</script>

/Users/cameron/code/camball.io/apps/blog/src/routes/[slug=metapage]/+page.svelte:21:69
Warn: This reference only captures the initial value of `data`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally (svelte)

    const { title, author, description, created, modified, tags } = data.metadata;

====================================
svelte-check found 0 errors and 5 warnings in 3 files
```

```text
Loading svelte-check in workspace: /Users/cameron/code/camball.io/apps/blog
Getting Svelte diagnostics...

svelte-check found 0 errors and 0 warnings
```

## Archive `svelte-check` Before/After

```text
Loading svelte-check in workspace: /Users/cameron/code/camball.io/apps/archive
Getting Svelte diagnostics...

/Users/cameron/code/camball.io/apps/archive/src/components/Loaders/Jellyfish.svelte:22:32
Warn: This reference only captures the initial value of `duration`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally (svelte)
    }: Props = $props();
    let durationUnit: string = duration.match(durationUnitRegex)?.[0] ?? "s";
    let durationNum: string = duration.replace(durationUnitRegex, "");

/Users/cameron/code/camball.io/apps/archive/src/components/Loaders/Jellyfish.svelte:23:31
Warn: This reference only captures the initial value of `duration`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally (svelte)
    let durationUnit: string = duration.match(durationUnitRegex)?.[0] ?? "s";
    let durationNum: string = duration.replace(durationUnitRegex, "");
</script>

====================================
svelte-check found 0 errors and 2 warnings in 1 file
```

```text
Loading svelte-check in workspace: /Users/cameron/code/camball.io/apps/archive
Getting Svelte diagnostics...

svelte-check found 0 errors and 0 warnings
```

---

closes #157