### PR TITLE
fix(blog): subtle header navigation animation issues

### DIFF
--- a/apps/blog/src/lib/header.svelte
+++ b/apps/blog/src/lib/header.svelte
@@ -8,40 +8,66 @@
     import { cn } from "@camball/ui/utils";
     import { Menu } from "@lucide/svelte";
     import { mode } from "mode-watcher";
-    import { onMount } from "svelte";
 
-    let previousScrollPosition = 0;
-    let header: HTMLDivElement | undefined = $state();
-    let spacer: HTMLDivElement | undefined = $state();
+    // Header initially flows with the document from the top to simply scroll off the page.
+    // Once it leaves the viewport, it transitions to a fixed overlay, with animation to hide
+    // on scroll down and show on scroll up, and a spacer div to smoothly scroll up to, until
+    // the header locks back into flowing with the document when we reach the very top again.
+    let previousScrollY = 0;
+    let isNavigatingViaHashClick = false;
+    let isFixedOverlay = $state(false);
+    let shouldHideHeader = $state(false);
+    let shouldAnimateTransform = $state(false);
+    let headerHeight = $state(0);
 
-    const handleScroll = () => {
-        const scrollPosition = window.scrollY || document.documentElement.scrollTop;
-        if (scrollPosition <= 0) {
-            // when scroll position returns to very top, use relative positioning
-            spacer?.classList.add("hidden");
-            header?.classList.remove("fixed");
-            header?.classList.remove("transition-transform", "duration-300");
-        } else if (scrollPosition > (header?.offsetHeight ?? 0)) {
-            // when scroll position goes past header height, apply animation
-            spacer?.classList.remove("hidden");
-            if (scrollPosition > previousScrollPosition) {
-                header?.classList.add("fixed");
-                header?.classList.add("-translate-y-full"); // on scroll down
-            } else {
-                header?.classList.add("transition-transform", "duration-300");
-                header?.classList.remove("-translate-y-full"); // on scroll up
-            }
-        }
-        previousScrollPosition = scrollPosition <= 0 ? 0 : scrollPosition;
+    const clearHashClickNavigation = () => (isNavigatingViaHashClick = false);
+
+    const onHashAnchorClick = (event: MouseEvent) => {
+        const href = (event.target as Element).closest("a[href^='#']")?.getAttribute("href");
+        if (!href || href === "#") return;
+        isNavigatingViaHashClick = true;
+        shouldHideHeader = true; // Can always hide here; don't want to show when clicking a header above *or* below.
+        shouldAnimateTransform = false;
+        if (window.scrollY > 0) isFixedOverlay = true;
     };
 
-    onMount(() => {
-        window.addEventListener("scroll", handleScroll);
-        return () => window.removeEventListener("scroll", handleScroll);
-    });
+    const onScroll = () => {
+        const currentScrollY = window.scrollY;
+
+        if (currentScrollY <= 0) {
+            // At the top of the document
+            isFixedOverlay = false;
+            shouldHideHeader = false;
+            shouldAnimateTransform = false;
+            clearHashClickNavigation();
+        } else if (isNavigatingViaHashClick) {
+            // Special case to not show header when navigating up to a heading
+            isFixedOverlay = true;
+            shouldHideHeader = true;
+        } else if (currentScrollY >= headerHeight) {
+            // The initial document-flow header is no longer in viewport, so transition to fixed-position overlay mode.
+            isFixedOverlay = true;
+            shouldHideHeader = currentScrollY > previousScrollY;
+            if (!shouldHideHeader) shouldAnimateTransform = true;
+        }
+
+        // Track to compare against next time we scroll
+        previousScrollY = Math.max(0, currentScrollY);
+    };
 </script>
 
-<div bind:this={header} class="top-0 left-0 z-50 w-full bg-stone-100 dark:bg-stone-900">
+<svelte:window onscroll={onScroll} onscrollend={clearHashClickNavigation} />
+<svelte:document onclick={onHashAnchorClick} />
+
+<div
+    bind:offsetHeight={headerHeight}
+    class={[
+        "top-0 z-50 w-full bg-stone-100 dark:bg-stone-900",
+        isFixedOverlay && "fixed left-0",
+        isFixedOverlay && shouldHideHeader && "-translate-y-full",
+        shouldAnimateTransform && "transition-transform duration-300",
+    ]}
+>
     <div class="site-container flex items-center justify-between px-3 py-2 sm:px-4">
         <div class="flex items-center space-x-6">
             <a href="/">
@@ -86,4 +112,7 @@
         </Drawer.Root>
     </div>
 </div>
-<div bind:this={spacer} class="top-0 left-0 hidden h-16 w-full"></div>
+<!-- If in `isFixedOverlay` mode, add a `headerHeight` spacer so the article doesn't jump. -->
+{#if isFixedOverlay}
+    <div style="height: {headerHeight}px"></div>
+{/if}


### PR DESCRIPTION
## Description

Same core logic as before, even though most of the literal lines of code themselves changed.

- **Refactor:** Track state via Svelte `$state` runes, instead of imperatively modifying the class list of elements. This is how it should have always been written, where the HTML is effectively declarative and state truly is only managed in Svelte.
- **Fix:** Because of the above refactor, the algorithm can now easily track when we are scrolling versus when we are clicking a heading and set state appropriately. With that, we solve the problem where the header was revealed when clicking a heading to navigate to that was above our current y scroll position, which always annoyed me, as the header covered up the heading we just clicked to navigate to. With this fixed, header navigations are *clean*. Love it.
- **Fix:** There was a super super tiny bug that existed in the previous algorithm implementation, where there was a 1px "bump" when scrolling from the very top (i.e., where the header flows with the document) down to where the header transitions to being a fixed-position overlay that dynamically hides/shows. It was very hard to notice, but was there if you scrolled down carefully enough. This was due to asking if the current y-scroll position is *greater than* the height of the header instead of greater than ***or equal to*** the height of the header. That 1px threshold difference became visible, and I never noticed before.

---

closes #163