### PR TITLE
feat(blog): table of contents on mobile

### DIFF
--- a/apps/blog/src/lib/header.svelte
+++ b/apps/blog/src/lib/header.svelte
@@ -2,12 +2,18 @@
     import logoDark from "@camball/ui/assets/cb_logo_dark.svg";
     import logoLight from "@camball/ui/assets/cb_logo_light.svg";
     import { HeaderDrawerContent, Socials, ThemeToggle } from "@camball/ui/components";
-    import { Drawer } from "@camball/ui/components/ui";
+    import { Drawer, Separator } from "@camball/ui/components/ui";
     import { buttonVariants } from "@camball/ui/components/ui/button";
     import { siteLinksEntries } from "@camball/ui/shared/site-links";
     import { cn } from "@camball/ui/utils";
-    import { Menu } from "@lucide/svelte";
+    import { Menu, TableOfContents } from "@lucide/svelte";
     import { mode } from "mode-watcher";
+
+    interface Props {
+        tocOpen?: boolean;
+    }
+
+    let { tocOpen = $bindable(false) }: Props = $props();
 
     // Header initially flows with the document from the top to simply scroll off the page.
     // Once it leaves the viewport, it transitions to a fixed overlay, with animation to hide
@@ -25,6 +31,8 @@
     const onHashAnchorClick = (event: MouseEvent) => {
         const href = (event.target as Element).closest("a[href^='#']")?.getAttribute("href");
         if (!href || href === "#") return;
+
+        tocOpen = false;
         isNavigatingViaHashClick = true;
         shouldHideHeader = true; // Can always hide here; don't want to show when clicking a header above *or* below.
         shouldAnimateTransform = false;
@@ -92,24 +100,39 @@
             <Socials imageSize="25px" class="space-x-3" />
         </div>
 
-        <Drawer.Root direction="top">
-            <Drawer.Trigger>
-                {#snippet child({ props })}
-                    <div
-                        {...props}
-                        class={cn(buttonVariants({ variant: "ghost" }), "p-1 sm:hidden")}
-                    >
-                        <Menu
-                            color={mode.current === "dark" ? "#EEE" : "#111"}
-                            size="28"
-                            strokeWidth="2.5"
-                            class="m-1"
-                        />
-                    </div>
-                {/snippet}
-            </Drawer.Trigger>
-            <HeaderDrawerContent />
-        </Drawer.Root>
+        <div class="flex items-center sm:hidden">
+            <button
+                type="button"
+                class={cn(buttonVariants({ variant: "ghost" }), "p-1")}
+                aria-expanded={tocOpen}
+                aria-controls="mobile-toc"
+                aria-label="Table of contents"
+                onclick={() => (tocOpen = !tocOpen)}
+            >
+                <TableOfContents
+                    color={mode.current === "dark" ? "#EEE" : "#111"}
+                    size="28"
+                    strokeWidth="2.5"
+                    class="m-1"
+                />
+            </button>
+            <Separator orientation="vertical" decorative class="mx-1 h-6! w-0.5!" />
+            <Drawer.Root direction="top">
+                <Drawer.Trigger>
+                    {#snippet child({ props })}
+                        <div {...props} class={cn(buttonVariants({ variant: "ghost" }), "p-1")}>
+                            <Menu
+                                color={mode.current === "dark" ? "#EEE" : "#111"}
+                                size="28"
+                                strokeWidth="2.5"
+                                class="m-1"
+                            />
+                        </div>
+                    {/snippet}
+                </Drawer.Trigger>
+                <HeaderDrawerContent />
+            </Drawer.Root>
+        </div>
     </div>
 </div>
 <!-- If in `isFixedOverlay` mode, add a `headerHeight` spacer so the article doesn't jump. -->

--- a/apps/blog/src/lib/toc-menu.svelte
+++ b/apps/blog/src/lib/toc-menu.svelte
@@ -1,0 +1,148 @@
+<!-- Had AI scrape the `vaul-svelte` Drawer component source and modify to -->
+<!-- create this. The original `vaul-svelte` Drawer captures and restores -->
+<!-- scroll position on close, which is undesirable for a table of contents -->
+<!-- (the whole point is to change the scroll position to the new heading), -->
+<!-- so when implementing the mobile table of contents, the agent copied most -->
+<!-- of the functionality of the original component, which works flawlessly. -->
+<script lang="ts">
+    import { ArrowUp } from "@lucide/svelte";
+
+    import type { TocItem } from "./toc";
+
+    const DURATION_MS = 500;
+    const EASE = "cubic-bezier(0.32, 0.72, 0, 1)";
+    const CLOSE_RATIO = 0.25;
+    const VELOCITY_THRESHOLD = 0.4;
+
+    const dampenValue = (v: number) => 8 * (Math.log(v + 1) - 2);
+
+    interface Props {
+        tocItems?: TocItem[];
+        open?: boolean;
+    }
+
+    let { tocItems = [], open = $bindable(false) }: Props = $props();
+
+    let displayed = $state(false);
+    let offsetY = $state(0);
+    let isDragging = $state(false);
+    let height = $state(0);
+    let pointerStartY = 0;
+    let dragStartMs = 0;
+
+    $effect(() => {
+        if (open) {
+            displayed = true;
+            isDragging = false;
+            offsetY = typeof window === "undefined" ? 0 : -window.innerHeight;
+            const frame = requestAnimationFrame(() => {
+                offsetY = 0;
+            });
+            return () => cancelAnimationFrame(frame);
+        }
+
+        isDragging = false;
+        if (displayed) offsetY = -Math.max(height, 1);
+    });
+
+    const close = () => (open = false);
+
+    const motionMs = () =>
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : DURATION_MS;
+
+    const overlayOpacity = $derived(1 - Math.min(1, Math.max(0, -offsetY) / Math.max(height, 1)));
+
+    const onTransformEnd = (event: TransitionEvent) => {
+        if (event.propertyName !== "transform" || open) return;
+        displayed = false;
+    };
+
+    const onPanelPointerDown = (event: PointerEvent) => {
+        if (event.button !== 0) return;
+        if ((event.target as Element).closest("nav, a, button")) return;
+        isDragging = true;
+        pointerStartY = event.pageY;
+        dragStartMs = Date.now();
+        (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    };
+
+    const onPanelPointerMove = (event: PointerEvent) => {
+        if (!isDragging) return;
+        const draggedDistance = event.pageY - pointerStartY;
+        offsetY = draggedDistance > 0 ? Math.max(0, dampenValue(draggedDistance)) : draggedDistance;
+    };
+
+    const onPanelPointerUp = (event: PointerEvent) => {
+        if (!isDragging) return;
+        isDragging = false;
+        const distMoved = pointerStartY - event.pageY;
+        const velocity = Math.abs(distMoved) / Math.max(Date.now() - dragStartMs, 1);
+
+        if (distMoved < 0) {
+            offsetY = 0;
+            return;
+        }
+        if (velocity > VELOCITY_THRESHOLD || -offsetY >= height * CLOSE_RATIO) close();
+        else offsetY = 0;
+    };
+</script>
+
+<svelte:window
+    onkeydown={(event) => {
+        if (event.key === "Escape") close();
+    }}
+/>
+
+{#if displayed}
+    <button
+        type="button"
+        class="fixed inset-0 z-60 backdrop-blur-lg sm:hidden"
+        style:opacity={overlayOpacity}
+        style:transition={isDragging ? "none" : `opacity ${motionMs()}ms ${EASE}`}
+        aria-label="Dismiss table of contents"
+        onclick={close}
+    ></button>
+    <div
+        id="mobile-toc"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-toc-title"
+        tabindex="-1"
+        bind:clientHeight={height}
+        class="fixed inset-x-0 top-0 z-60 flex max-h-[80vh] touch-none flex-col gap-5 rounded-b-lg border-b bg-background p-6 font-sans sm:hidden"
+        style:transform={`translate3d(0, ${offsetY}px, 0)`}
+        style:transition={isDragging ? "none" : `transform ${motionMs()}ms ${EASE}`}
+        style:will-change="transform"
+        onpointerdown={onPanelPointerDown}
+        onpointermove={onPanelPointerMove}
+        onpointerup={onPanelPointerUp}
+        onpointercancel={onPanelPointerUp}
+        ontransitionend={onTransformEnd}
+    >
+        <div
+            class="pointer-events-none absolute inset-x-0 bottom-full h-dvh bg-background"
+            aria-hidden="true"
+        ></div>
+        <p id="mobile-toc-title" class="text-xl font-semibold">Contents</p>
+        <nav class="flex touch-pan-y flex-col overflow-y-auto overscroll-contain">
+            {#each tocItems as item (item.href)}
+                <a
+                    href={item.href}
+                    class="mb-3 block"
+                    style:padding-left={`${(item.level - 2) * 0.75}rem`}
+                    onclick={close}
+                >
+                    {item.label}
+                </a>
+            {/each}
+        </nav>
+        <button
+            type="button"
+            class="self-end p-1"
+            aria-label="Close table of contents"
+            onclick={close}
+        >
+            <ArrowUp size="28px" />
+        </button>
+    </div>
+{/if}

--- a/apps/blog/src/lib/toc.ts
+++ b/apps/blog/src/lib/toc.ts
@@ -1,0 +1,32 @@
+import type { Attachment } from "svelte/attachments";
+
+export type TocItem = {
+    href: string;
+    label: string;
+    level: number;
+};
+
+/** Reads heading links from the rehype-generated desktop TOC into mobile menu items. */
+export function tocItemsFromElement(toc: Element | null): TocItem[] {
+    if (!toc) return [];
+
+    return [...toc.querySelectorAll<HTMLAnchorElement>("a.toc-link")].flatMap((anchor) => {
+        const href = anchor.getAttribute("href");
+        const label = anchor.textContent?.trim();
+        if (!href || !label) return [];
+
+        const levelMatch = /toc-link-h(\d)/.exec(anchor.className);
+        return [{ href, label, level: levelMatch ? Number(levelMatch[1]) : 2 }];
+    });
+}
+
+/** Watches the article for the appearance of a `nav.toc` element and keeps mobile TOC state in sync. */
+export function captureToc(setItems: (items: TocItem[]) => void): Attachment<HTMLElement> {
+    return (node) => {
+        const update = () => setItems(tocItemsFromElement(node.querySelector("nav.toc")));
+        update();
+        const observer = new MutationObserver(update);
+        observer.observe(node, { childList: true, subtree: true });
+        return () => observer.disconnect();
+    };
+}

--- a/apps/blog/src/routes/[slug=metapage]/+page.svelte
+++ b/apps/blog/src/routes/[slug=metapage]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import Header from "$lib/header.svelte";
+    import { captureToc, type TocItem } from "$lib/toc";
+    import TocMenu from "$lib/toc-menu.svelte";
     import { Footer, SiteMeta } from "@camball/ui/components";
     import { Separator } from "@camball/ui/components/ui";
     import { fade } from "svelte/transition";
@@ -18,6 +20,11 @@
     let { data }: Props = $props();
 
     const metadata = $derived(data.metadata);
+
+    // For custom TOC capture on mobile
+    let tocItems: TocItem[] = $state([]);
+    let tocOpen = $state(false);
+    const setTocItems = (items: TocItem[]) => (tocItems = items);
 </script>
 
 <SiteMeta
@@ -28,7 +35,8 @@
     type="article"
     tags={metadata.tags}
 />
-<Header />
+<Header bind:tocOpen />
+<TocMenu {tocItems} bind:open={tocOpen} />
 <div class="site-container">
     <header class="mx-5 my-7 space-y-3 font-medium sm:mx-16 md:mx-32 lg:mx-48" id="article-header">
         <Tags tags={metadata.tags} />
@@ -47,6 +55,7 @@
     </div>
     <Separator />
     <div
+        {@attach captureToc(setTocItems)}
         in:fade|global={{ delay: 150, duration: 350 }}
         out:fade|global={{ duration: 100 }}
         class="m-5 mt-7 mb-10 min-w-0 sm:mx-16 sm:flex sm:flex-row md:mx-32 lg:mx-60"


### PR DESCRIPTION
## Demo

| Header button | Open TOC Drawer |
| --- | --- |
| ![mobile-toc-in-header](https://github.com/user-attachments/assets/000e9fda-bd44-444b-a28c-d9a76055ecea) | ![mobile-toc-open](https://github.com/user-attachments/assets/84a66f13-541d-4a64-a2da-03e06fde3c53) |

---

closes #167