### PR TITLE
fix(blog): toml formatting conflict between tailwind and prism

### DIFF
--- a/apps/blog/src/app.css
+++ b/apps/blog/src/app.css
@@ -57,3 +57,9 @@ nav > :last-child.toc-level {
 .prose :where(:not(pre) > code) {
     overflow-wrap: anywhere;
 }
+
+/* Prism TOML table headers use a `table` token class, which Tailwind also exposes as */
+/* `display: table`, thus erroneously putting `[`, `build`, and `]` on separate lines. */
+.prose :where(pre code .table) {
+    display: inline;
+}


### PR DESCRIPTION
## Description

**Class name collision:** Prism (syntax highlighting library for codeblocks) marks TOML table headers with `class="token table class-name"`. Tailwind v4 also ships a `.table { display: table }` utility, so in the rendered TOML, something like `build` in a TOML array `[build]` was rendered as a table box, putting `[`, `build`, and `]` all on separate lines. The same issue applied to TOML arrays of tables, e.g., `[[services]]`.

This must have been a regression at some point, because I don't recall seeing this issue when first writing that blog article.

## Demo

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/eb7bd62c-876a-4bfc-9aea-be7d7099891a) | ![after](https://github.com/user-attachments/assets/b40bdb14-1982-4bc7-b816-ebcf43e1281f) |

---

closes #168